### PR TITLE
Dynamic removal of Container ID without relying on string length

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -2,5 +2,8 @@
 homepage: "https://www.reprisedigital.com"
 versions:
   # Latest version
+  - sha: b305f057e92a676d9bc461c36174f05ba09f93a2
+    changeNotes: Code refactor and dynamic removal of Container ID from cookie value.
+  # Initial version
   - sha: 549697ee65572d9f64f66c194f98e1bd5f7771bc
     changeNotes: Initial release.

--- a/template.tpl
+++ b/template.tpl
@@ -32,13 +32,13 @@ const getContainerVersion = require('getContainerVersion');
 const getCookieValues = require('getCookieValues');
 const toBase64 = require('toBase64');
 
-const containerId = getContainerVersion()['containerId'];
+const containerId = getContainerVersion().containerId;
 
 // Retrieve cookie values
 const previewCookiesToBase64 = 
   ['gtm_preview', 'gtm_auth', 'gtm_debug']
   .map(previewCookieName => getCookieValues(previewCookieName)[0])
-  .map(previewCookie => previewCookie.replace(containerId, ''))
+  .map(previewCookie => previewCookie.replace(containerId + '=', ''))
   .join('|');
 
 // Encode it with base64 to get the X-Gtm-Preview-Header

--- a/template.tpl
+++ b/template.tpl
@@ -28,21 +28,21 @@ ___TEMPLATE_PARAMETERS___
 
 ___SANDBOXED_JS_FOR_SERVER___
 
+const getContainerVersion = require('getContainerVersion');
 const getCookieValues = require('getCookieValues');
 const toBase64 = require('toBase64');
 
-//Retrieve cookie values
-var gtm_preview = getCookieValues('gtm_preview')[0];
-var gtm_auth = getCookieValues('gtm_auth')[0];
-var gtm_debug = getCookieValues('gtm_debug')[0];
+const containerId = getContainerVersion()['containerId'];
 
-gtm_preview = gtm_preview.substring(12, 50);  //Remove container ID from cookie value
-gtm_auth = gtm_auth.substring(12, 50);  //Remove container ID from cookie value
-gtm_debug = gtm_debug.substring(12, 50);  //Remove container ID from cookie value
+// Retrieve cookie values
+const previewCookiesToBase64 = 
+  ['gtm_preview', 'gtm_auth', 'gtm_debug']
+  .map(previewCookieName => getCookieValues(previewCookieName)[0])
+  .map(previewCookie => previewCookie.replace(containerId, ''))
+  .join('|');
 
-var to_base_64 = gtm_preview+'|'+gtm_auth+'|'+gtm_debug;  //Putting all the cookies together devided by |
-
-const x_gtm_server_preview = toBase64(to_base_64);  //Encode it with base64 to get the X-Gtm-Preview-Header
+// Encode it with base64 to get the X-Gtm-Preview-Header
+const x_gtm_server_preview = toBase64(previewCookiesToBase64);  
 
 return x_gtm_server_preview;
 


### PR DESCRIPTION
Hello.

I've modified the code to replace the Container ID from cookies values without relying on the string length, as it might change depending on the Container ID.

And also refactored the code.